### PR TITLE
Support iteration with manually called next()

### DIFF
--- a/TwitterSearch/TwitterSearch.py
+++ b/TwitterSearch/TwitterSearch.py
@@ -173,8 +173,6 @@ class TwitterSearch(object):
 
     # Iteration
     def __iter__(self):
-        if not self.__response:
-            raise TwitterSearchException(1014)
         self._nextTweet = 0
         return self
 
@@ -183,6 +181,9 @@ class TwitterSearch(object):
         return self.__next__()
 
     def __next__(self):
+        if not self.__response:
+            raise TwitterSearchException(1014)
+
         if self._nextTweet < len(self.__response['content']['statuses']):
             self._nextTweet += 1
             return self.__response['content']['statuses'][self._nextTweet-1]


### PR DESCRIPTION
Currently, if one calls `next()` method on tweet iterable, it raises exception, because `_nextTweet` is defined in `__iter__()`. I fixed it and also moved the check of `__response` existence to `next()`, so it raises `'No results available'` exception, if there's no response.
