### PR TITLE
fix pagination when using max_id in base url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change history
 **************
 
+1.0.3
+#####
+
+* fix pagination when using max_id in base url
+
 1.0.1
 #####
 

--- a/TwitterSearch/TwitterSearch.py
+++ b/TwitterSearch/TwitterSearch.py
@@ -11,8 +11,10 @@ from .utils import py3k
 
 try:
     from urllib.parse import parse_qs  # python3
+    from urllib.parse import urlencode
 except ImportError:
     from urlparse import parse_qs  # python2
+    from urllib import urlencode
 
 # determine max int value
 try:
@@ -319,9 +321,11 @@ class TwitterSearch(object):
         if not self.__next_max_id:
             raise TwitterSearchException(1011)
 
-        self.send_search(
-            "%s&max_id=%i" % (self._start_url, self.__next_max_id)
-        )
+        params = parse_qs(self._start_url[1:])
+        params['max_id'] = self.__next_max_id
+        url = self._start_url[0] + urlencode(params, doseq=True)
+
+        self.send_search(url)
         return True
 
     def get_metadata(self):


### PR DESCRIPTION
Fixes a bug occuring when using set_max_id on the TwitterSearchOrder object. The problem was that the base url contained a max_id parameter, for which the pagination didn't account for, leading to two max_id parameters in the URL of the second page. This lead to wrong results.